### PR TITLE
[TASK] Update composer.json license definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
       env: TYPO3=^7.6
 
     - stage: publish to ter
+      if: tag IS present
       php: 7.1
       before_install: skip
       install: skip

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "typo3-cms-extension",
 	"description": "TYPO3 Jump URL handling",
 	"homepage": "https://typo3.org",
-	"license": ["GPL-2.0+"],
+	"license": "GPL-2.0-or-later",
 	"require": {
 		"typo3/cms-core": "^7.6 || ^8.0",
 		"typo3/cms-frontend": "^7.6 || ^8.0"


### PR DESCRIPTION
Composer license definition GPL-2.0+ has been deprecated and has to be
replaced with GPL-2.0-or-later.