### PR TITLE
Task: Allow sections in links

### DIFF
--- a/Classes/JumpUrlHandler.php
+++ b/Classes/JumpUrlHandler.php
@@ -108,6 +108,9 @@ class JumpUrlHandler implements UrlHandlerInterface
             $pageTSconfig = [];
         }
 
+        // Allow sections in links
+        $jumpUrl = str_replace('%23', '#', $jumpUrl);
+
         $jumpUrl = $this->addParametersToTransferSession($jumpUrl, $pageTSconfig);
         $statusCode = $this->getRedirectStatusCode($pageTSconfig);
         $this->redirect($jumpUrl, $statusCode);

--- a/Tests/Unit/JumpUrlHandlerTest.php
+++ b/Tests/Unit/JumpUrlHandlerTest.php
@@ -96,6 +96,10 @@ class JumpUrlHandlerTest extends UnitTestCase
                 '8591c573601d17f37e06aff4ac14c78f107dd49e',
                 'http://external.domain.tld',
             ],
+            'URL with section' => [
+                '3723eefe766e38f9a2ea8d2cd84f6519d7d30b75',
+                str_replace('%23', '#','http://external.domain.tld/' . rawurlencode('#c123')),
+            ],
             'Mailto link' => [
                 'bd82328dc40755f5d0411e2e16e7c0cbf33b51b7',
                 'mailto:mail@ddress.tld',


### PR DESCRIPTION
To support links with sections, eg. www.external.domain/#c123

We have newsletter links with sections which normally does not work. Here we care about the encoding: kartolo/direct_mail@b1c473b

In this extension we need to decode %23 to # not to get a 404

