### PR TITLE
[BUGFIX] Correct Typehint

### DIFF
--- a/Classes/JumpUrlProcessor.php
+++ b/Classes/JumpUrlProcessor.php
@@ -203,9 +203,9 @@ class JumpUrlProcessor implements UrlProcessorInterface
         return $linkParameter;
     }
 
-    protected function getTypoScriptFrontendController(): TypoScriptFrontendController
+    protected function getTypoScriptFrontendController(): ?TypoScriptFrontendController
     {
-        return $this->frontendController ?? $GLOBALS['TSFE'];
+        return $this->frontendController ?? $GLOBALS['TSFE']
     }
 
     protected function getContentObjectRenderer(): ContentObjectRenderer


### PR DESCRIPTION
The change prevents exception the Exception 

`Return value of FoT3\Jumpurl\JumpUrlProcessor::getTypoScriptFrontendController() must be an instance of TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController, null returned`

The change relates to: #23 and makes it possible to use the redirects module. The change may not resolve #23 fully.