### PR TITLE
[TASK] Add extension-key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
 	"extra": {
 		"typo3/cms": {
 			"cms-package-dir": "{$vendor-dir}/typo3/cms",
+			"extension-key": "jumpurl",
 			"web-dir": ".Build/Web"
 		}
 	}


### PR DESCRIPTION
Extends composer.json with the extension-key due to:

> TYPO3 Extension Package "friendsoftypo3/jumpurl", does not define extension key in composer.json.
> Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)

