### PR TITLE
[UPDATE] Mark as compatible with TYPO3 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
 	"homepage": "https://typo3.org",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"typo3/cms-core": "^9.0 || ^10.0",
-		"typo3/cms-frontend": "^9.0 || ^10.0"
+		"typo3/cms-core": "^9.0 || ^10.0 || ^11.0",
+		"typo3/cms-frontend": "^9.0 || ^10.0 || ^11.0"
 	},
 	"require-dev": {
 		"nimut/testing-framework": "^5.0",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,10 +10,10 @@ $EM_CONF[$_EXTKEY] = array(
     'createDirs' => '',
     'clearCacheOnLoad' => 1,
     'author_company' => '',
-    'version' => '8.0.2',
+    'version' => '8.0.3',
     'constraints' => array(
         'depends' => array(
-            'typo3' => '9.5.0-10.9.99',
+            'typo3' => '9.5.0-11.9.99',
         ),
         'conflicts' => array(),
         'suggests' => array(),


### PR DESCRIPTION
I tested the extension with TYPO3 11 LTS and it works as expected. Please, release `8.0.3` to make it officially available :)

Thanks!