### PR TITLE
[BUGFIX] Prevent 'Undefined array key "TSFE."'

### DIFF
--- a/Classes/Middleware/JumpUrlHandler.php
+++ b/Classes/Middleware/JumpUrlHandler.php
@@ -84,7 +84,7 @@ class JumpUrlHandler implements MiddlewareInterface
     protected function redirectToJumpUrl(string $jumpUrl): ResponseInterface
     {
         $pageTSconfig = $this->getTypoScriptFrontendController()->getPagesTSconfig();
-        $pageTSconfig = is_array($pageTSconfig['TSFE.']) ? $pageTSconfig['TSFE.'] : [];
+        $pageTSconfig = isset($pageTSconfig['TSFE.']) && is_array($pageTSconfig['TSFE.']) ? $pageTSconfig['TSFE.'] : [];
 
         // Allow sections in links
         $jumpUrl = str_replace('%23', '#', $jumpUrl);


### PR DESCRIPTION
Key 'TSFE.' does not always exit in $pageTSconfig - causing an error with PHP 8.1