### PR TITLE
Prevent Undefined array key Warning

### DIFF
--- a/Classes/Middleware/JumpUrlHandler.php
+++ b/Classes/Middleware/JumpUrlHandler.php
@@ -84,7 +84,7 @@ class JumpUrlHandler implements MiddlewareInterface
     protected function redirectToJumpUrl(string $jumpUrl): ResponseInterface
     {
         $pageTSconfig = $this->getTypoScriptFrontendController()->getPagesTSconfig();
-        $pageTSconfig = is_array($pageTSconfig['TSFE.'] ?? false) ? $pageTSconfig['TSFE.'] : [];
+        $pageTSconfig = array_key_exists('TSFE.', $pageTSconfig) && is_array($pageTSconfig['TSFE.'] ?? false) ? $pageTSconfig['TSFE.'] : [];
 
         // Allow sections in links
         $jumpUrl = str_replace('%23', '#', $jumpUrl);


### PR DESCRIPTION
Core: Error handler (FE): PHP Warning: Undefined array key "TSFE." in /var/www/vhosts/meineseite.at/httpdocs/ProjektDeploy/releases/20230628080408/vendor/friendsoftypo3/jumpurl/Classes/Middleware/JumpUrlHandler.php line 87